### PR TITLE
fix: Removed unused Document link in sidebar

### DIFF
--- a/get-me-hired-v2/src/components/dashboard/sidebar.tsx
+++ b/get-me-hired-v2/src/components/dashboard/sidebar.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
-import { FileText, LayoutDashboard, Briefcase, Sparkles, User, Settings, LogOut, FolderOpen } from "lucide-react";
+import { FileText, LayoutDashboard, Briefcase, Sparkles, User, Settings, LogOut } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { authHelpers } from "@/lib/auth";
@@ -13,7 +13,6 @@ const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/applications", label: "Applications", icon: Briefcase },
   { href: "/generate", label: "Generate", icon: Sparkles },
-  { href: "/documents", label: "Documents", icon: FolderOpen },
   { href: "/profile", label: "Profile", icon: User },
 ];
 


### PR DESCRIPTION
- Removed Documents link from sidebar and any references to it, this is due to a decision change to not have a global view to documents and instead tie them to their respective Job Applications.